### PR TITLE
Mitigate DNS issues by the ndots value

### DIFF
--- a/kubernetes/litecoind/templates/statefulset.yaml
+++ b/kubernetes/litecoind/templates/statefulset.yaml
@@ -28,6 +28,10 @@ spec:
       serviceAccountName: {{ include "litecoind.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: '1'
       containers:
         - name: {{ .Chart.Name }}
           securityContext:


### PR DESCRIPTION
I noticed DNS errors when the `litecoind` containers start:

```
Adding fixed seed nodes as DNS doesn't seem to be available.
```

I reckon the workload is not patient enough to wait for Kubernetes' default resolving settings. By lowering the `ndots` setting from `5` (default) to `1`, we can force the scheduler to send all the workloads DNS requests directly to the DNS server.

By default, every request for a domain name that contains fewer than 5 dots has to endure et least 3 local search cycles, as Kubernetes tries to resolve its common `search` patterns.

- [x] lower ndots setting
- [x] verify that DNS errors are gone on startup