### PR TITLE
Define a TCP readiness probe

### DIFF
--- a/kubernetes/litecoind/templates/statefulset.yaml
+++ b/kubernetes/litecoind/templates/statefulset.yaml
@@ -46,6 +46,14 @@ spec:
           {{- if .Values.container.testnet }}
             - -testnet
           {{- end }}
+          readinessProbe:
+            tcpSocket:
+              {{- if .Values.container.testnet }}
+              port: {{ .Values.container.testnetPort }}
+              {{- else }}
+              port: {{ .Values.container.port }}
+              {{- end }}
+            initialDelaySeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/kubernetes/litecoind/values.yaml
+++ b/kubernetes/litecoind/values.yaml
@@ -41,10 +41,10 @@ securityContext:
 container:
   command:
     - /usr/local/bin/litecoind
-  additionalArgs:
-
-    # listen to rpc connections for probes?
+  additionalArgs: []
+  port: 9333
   testnet: true
+  testnetPort: 19335
 
 resources:
   limits:


### PR DESCRIPTION
By default, the application will listen on TCP `9333` and on `19335` in testnet mode.
The readiness probe waits an initial 10 seconds, before probing the workload. Usually enough for `litecoind` to start and bind.