### PR TITLE
Use container user for fsGroup

### DIFF
--- a/kubernetes/litecoind/values.yaml
+++ b/kubernetes/litecoind/values.yaml
@@ -27,8 +27,8 @@ managedBy: Helm
 
 podAnnotations: {}
 
-podSecurityContext: {}
-  # fsGroup: 2000
+podSecurityContext:
+  fsGroup: 65532
 
 securityContext:
   capabilities:


### PR DESCRIPTION
This change-set uses the containers' non-root user group for the filesystem group in the Pod's security context.