### PR TITLE
Add `grype` security audit of the container image to the test pipeline

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,6 +26,11 @@ jobs:
           docker run --rm curlimages/curl --fail-with-body --silent --retry 3 \
             https://raw.githubusercontent.com/rancher/k3d/main/install.sh | bash
 
+      - name: Install grype
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
+            | sh -s -- -b /usr/local/bin
+
       - name: Run test suite
         run: |
           just test clean

--- a/docs/Justfile.md
+++ b/docs/Justfile.md
@@ -17,6 +17,7 @@ The `justfile` provides various recipes to:
 - [`helm`](https://helm.sh/) (`3.x`)
 - [`kubectl`](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - [`k3d`](https://k3d.io) (`5.x`)
+- [`grype`](https://github.com/anchore/grype)
 
 ### Optional
 

--- a/justfile
+++ b/justfile
@@ -53,6 +53,10 @@ build-image:
 push-image:
   docker push "{{image}}"
 
+# run security audit on the container image
+audit-image:
+  grype docker:"{{image}}"
+
 # render the kubernetes manifests
 render:
   helm template litecoind kubernetes/litecoind \


### PR DESCRIPTION
This change-set adds the `grype` security scanner.
https://github.com/anchore/grype